### PR TITLE
Update README with free-drive mode and map centering details

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ GpxPlayerDesktop is a modern desktop application built with Kotlin and Jetpack C
 - 📍 GPX file loading and map visualization
 - 🛰️ Simulated playback with speed control
 - 🎯 Location marker with heading orientation
+- 🚗 Free-drive mode with keyboard steering and live speed/heading readouts
+- 🧭 Optional map centering based on approximate IP geolocation when idle
 - 📡 ADB integration to send mock locations to connected Android devices
 - ☁️ Interface with [GpxPlayer for Android](https://github.com/Pygmalion69/GpxPlayerAndroid)
 - 🌍 Interactive map (Leaflet.js) embedded via JavaFX WebView
@@ -42,3 +44,15 @@ or build native distributions:
 3. Press **Play** to simulate the route on the map.
 4. Use **Stop** to cancel simulation.
 
+### Free Drive Mode
+
+1. Click **Free drive** to enter free-drive mode (GPX playback will pause if active).
+2. Pan the map to the desired start point and click **Set Position**.
+3. Use the arrow keys to control the simulated vehicle:
+   - **↑/↓** accelerate or decelerate.
+   - **←/→** steer left or right.
+4. Click **Clear position** to reset the free-drive session.
+
+When no GPX track is loaded or vehicle position is set, the map automatically centers to an
+approximate location based on IP geolocation (falling back to the default map center if
+geolocation is unavailable).


### PR DESCRIPTION
### Motivation
- Document the recently added free-drive mode (keyboard steering with live speed/heading) and the automatic initial map centering via IP geolocation so the user-facing `README.md` reflects the code changes.

### Description
- Updated `README.md` to add feature lines for free-drive and IP-based centering and added a `Free Drive Mode` usage section describing how to enter the mode, use `Set Position` / `Clear position`, control with arrow keys, and the automatic centering fallback.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698842f7fe0c83279f3c3ac4cd80144b)