### PR TITLE
Allow release workflow to trigger on numeric tags without leading 'v'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: Release GpxPlayerDesktop
 on:
   push:
     tags:
-      - 'v*' # Only trigger on tags starting with 'v'
+      - 'v*' # Tags starting with 'v'
+      - '[0-9]*' # Version tags without a leading 'v'
 
 jobs:
   release:


### PR DESCRIPTION
### Motivation
- Ensure the GitHub Actions release workflow runs for version tags that are numeric (e.g. `1.2.3`) in addition to tags prefixed with `v` (e.g. `v1.2.3`).

### Description
- Updated `.github/workflows/release.yml` to add the tag pattern `"[0-9]*"` to `push.tags` so the release job triggers for numeric version tags as well as `v*` tags.

### Testing
- No automated tests were run because this is a workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698851f7099c832785e327f7e10e76d3)