### PR TITLE
Fix release workflow token permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - 'v*' # Tags starting with 'v'
       - '[0-9]*' # Version tags without a leading 'v'
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Release on ${{ matrix.os }}
@@ -43,5 +46,6 @@ jobs:
           name: GpxPlayerDesktop ${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}
           files: build/compose/binaries/**/*
+          token: ${{ secrets.GITHUB_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation
- Fix 403 `Resource not accessible by integration` when creating a GitHub release with `softprops/action-gh-release@v2` by ensuring the release job has a write-capable token.

### Description
- Add workflow-level `permissions` with `contents: write` so the default `GITHUB_TOKEN` can create releases.
- Pass `token: ${{ secrets.GITHUB_TOKEN }}` to `softprops/action-gh-release@v2` explicitly for clarity and compatibility.
- Preserve `GITHUB_TOKEN` in the job `env` for backwards compatibility.

### Testing
- No automated tests were run because this change only modifies the GitHub Actions workflow configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69885b51033083279d2c08cfc2c46c84)