### PR TITLE
Align JavaFX dependencies with Java 17 runtime

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
 
     // JavaFX Modules
-    val javafxVersion = "21"
+    val javafxVersion = "17.0.2"
 
     implementation("org.openjfx:javafx-controls:$javafxVersion")
     implementation("org.openjfx:javafx-swing:$javafxVersion")


### PR DESCRIPTION
### Motivation
- The project toolchain targets Java 17 via `java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }` while the dependency variable was set to JavaFX `21`, causing a runtime mismatch that prevented the packaged Windows executable from launching the JVM.

### Description
- Updated the JavaFX dependency version in `build.gradle.kts` by changing `val javafxVersion` from `"21"` to `"17.0.2"` to match the configured Java 17 runtime.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989b0e65b24832789cd6418998672fa)