### PR TITLE
Add java.desktop module to native distributions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,6 +59,7 @@ compose.desktop {
     application {
         mainClass = "MainKt"
         nativeDistributions {
+            modules("java.desktop")
             targetFormats(
                 TargetFormat.Exe,
                 TargetFormat.Deb)


### PR DESCRIPTION
### Motivation
- Windows builds using `JFXPanel` threw `NoClassDefFoundError` for `jdk/swing/interop/SwingInterOpUtils` because the `java.desktop` module was not included in the packaged runtime, so it must be bundled to restore Swing/JavaFX interop.

### Description
- Added `modules("java.desktop")` to `compose.desktop.application.nativeDistributions` in `build.gradle.kts` to include the `java.desktop` module in native packages.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989ec2418588327b17dd1353c4d5944)