### PR TITLE
Include jdk.unsupported.desktop in packaged runtime image

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,7 +59,10 @@ compose.desktop {
     application {
         mainClass = "MainKt"
         nativeDistributions {
-            modules("java.desktop")
+            modules(
+                "java.desktop",
+                "jdk.unsupported.desktop"
+            )
             targetFormats(
                 TargetFormat.Exe,
                 TargetFormat.Deb)


### PR DESCRIPTION
### Motivation
- The Windows build was crashing at runtime with `NoClassDefFoundError: jdk/swing/interop/SwingInterOpUtils`, which is required by JavaFX `JFXPanel` Swing interop and can be omitted from a jlinked runtime image.
- Ensure the native packaged runtime includes the module that provides Swing interop classes so the EXE/installer no longer fails on startup.

### Description
- Added `"jdk.unsupported.desktop"` to the `modules` list in `compose.desktop.application.nativeDistributions` inside `build.gradle.kts` so the packaged runtime includes the unsupported desktop module alongside `java.desktop`.
- No other build settings or target formats were changed.

### Testing
- Ran `./gradlew -q help` which completed successfully. 
- Attempted `./gradlew packageDistributionForCurrentOS` which could not complete in this environment due to a missing local Java 17 toolchain (`Cannot find a Java installation ... languageVersion=17`), so full packaging was not validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b68e6f01bc83278422a25423ea88c4)