### PR TITLE
Fix Windows map loading crash by bundling java.net.http module

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,7 @@ compose.desktop {
         nativeDistributions {
             modules(
                 "java.desktop",
+                "java.net.http",
                 "jdk.unsupported.desktop"
             )
             targetFormats(


### PR DESCRIPTION
### Motivation
- Windows packaged app crashed when loading the map with `NoClassDefFoundError: java/net/http/HttpResponse$BodySubscriber`, indicating the Java HTTP client module was not included in the custom runtime image.
- The `/usr/bin/adb` path warning is a known/non-blocking issue and was intentionally left unchanged for this fix.

### Description
- Add `"java.net.http"` to `compose.desktop.application.nativeDistributions.modules` in `build.gradle.kts` so the packaged runtime includes the Java HTTP client classes used by JavaFX `WebView`.
- This is a one-line change in `build.gradle.kts` that ensures the `java.net.http` module is bundled into native distributions.

### Testing
- Ran `./gradlew --no-daemon clean compileKotlin` to validate the build configuration.
- The build could not be completed in this environment because the JDK 17 toolchain is not installed (`Cannot find a Java installation ... languageVersion=17`), so compilation could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e207440c808327bb89ff451b28a564)