### PR TITLE
Include jdk.unsupported module for JavaFX Marlin renderer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,8 @@ compose.desktop {
             modules(
                 "java.desktop",
                 "java.net.http",
-                "jdk.unsupported.desktop"
+                // Required by JavaFX Marlin renderer (uses sun.misc.Unsafe).
+                "jdk.unsupported"
             )
             targetFormats(
                 TargetFormat.Exe,


### PR DESCRIPTION
### Motivation
- The packaged runtime omitted the `jdk.unsupported` module, causing startup failures like `java.lang.NoClassDefFoundError: sun/misc/Unsafe` and `Could not initialize class com.sun.marlin.DMarlinRenderingEngine` on the Windows installer.

### Description
- Updated `build.gradle.kts` to replace the incorrect `jdk.unsupported.desktop` entry with `jdk.unsupported` in the Compose `nativeDistributions` `modules` list and added a comment noting this is required for the JavaFX Marlin renderer.

### Testing
- Ran `./gradlew --no-daemon clean compileKotlin`, which failed in this environment due to no matching local JDK 17 toolchain being available, so automated runtime verification (packaging and installer generation) was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fefcc09f2c8327a7e4d45404830d81)