### PR TITLE
ci: migrate GitHub Actions to Node 24-compatible actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: Build on ${{ matrix.os }}
@@ -17,10 +20,10 @@ jobs:
 
     steps:
       - name: 🧾 Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: ☕ Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release:
     name: Release on ${{ matrix.os }}
@@ -19,10 +22,10 @@ jobs:
 
     steps:
       - name: 🧾 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: ☕ Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17


### PR DESCRIPTION
### Motivation
- Address GitHub Actions Node.js 20 deprecation warnings by moving repository workflows to actions that are compatible with Node.js 24 and opt the workflows into Node 24 immediately.

### Description
- Updated `.github/workflows/build.yml` and `.github/workflows/release.yml` to use `actions/checkout@v5` instead of older major versions. 
- Updated both workflows to use `actions/setup-java@v5` for the JDK setup step. 
- Added a workflow-level `env` entry setting `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` in both files to opt in to Node.js 24 now. 
- Confirmed there is no usage of `gradle/actions/setup-gradle@v4` in tracked workflow files, so no change was required for that action.

### Testing
- Ran repository searches with `rg` to locate action usages and the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` token and confirmed the updated versions and env are present, which succeeded. 
- Verified the exact edits with `git diff -- .github/workflows/build.yml .github/workflows/release.yml`, which showed the expected replacements and additions and succeeded. 
- Committed the change and inspected the updated workflow files (`.github/workflows/build.yml` and `.github/workflows/release.yml`) to confirm the applied changes, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09990913748327912d8b080405db7d)