### PR TITLE
ci: upgrade workflow actions for Node.js 24 transition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: Build on ${{ matrix.os }}
@@ -17,10 +20,10 @@ jobs:
 
     steps:
       - name: 🧾 Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: ☕ Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release:
     name: Release on ${{ matrix.os }}
@@ -19,10 +22,10 @@ jobs:
 
     steps:
       - name: 🧾 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: ☕ Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17


### PR DESCRIPTION
### Motivation
- GitHub Actions is deprecating Node.js 20 and workflows in this repo were using action releases that emit Node 20 warnings, so the workflows need to be moved to Node 24-compatible majors now. 
- Opting into Node.js 24 early avoids deprecation warnings and reduces risk of runner breakage when Node 24 becomes the default.

### Description
- Updated `actions/checkout` to `@v5` in both `.github/workflows/build.yml` and `.github/workflows/release.yml` to pick a Node 24-compatible major. 
- Updated `actions/setup-java` to `@v5` in both workflows to ensure compatibility with the runner's Node 24 transition. 
- Added workflow-level environment variable `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to both `build.yml` and `release.yml` to opt into Node.js 24 immediately.

### Testing
- Ran repository scans with `rg` to locate usages of the affected actions and the searches succeeded. 
- Printed and inspected workflow contents with `sed`/`nl` to verify the new `uses:` lines and `env` setting and the inspections succeeded. 
- Executed the scripted update (`python` script) and validated the result with `git diff` to confirm only workflow files were modified and those checks succeeded. 
- Queried the action releases with a web search to confirm `@v5` is available and the lookup succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09993998608327beff217b78d397b9)