### PR TITLE
Bundle JavaFX runtime modules in native distribution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,16 +58,12 @@ compose.desktop {
         mainClass = "MainKt"
         javaHome = nativePackageJavaHome.get()
         nativeDistributions {
+            // Keep explicit JDK modules and let Compose include dependency modules (JavaFX).
+            includeAllModules = true
             modules(
                 "java.desktop",
                 "jdk.httpserver",
                 "java.net.http",
-                // JavaFX runtime modules required at package runtime.
-                "javafx.base",
-                "javafx.graphics",
-                "javafx.controls",
-                "javafx.swing",
-                "javafx.web",
                 // Required by JavaFX Marlin renderer (uses sun.misc.Unsafe).
                 "jdk.unsupported",
                 // Required by javafx.swing/JFXPanel on Windows for Swing event interop.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,12 @@ compose.desktop {
                 "java.desktop",
                 "jdk.httpserver",
                 "java.net.http",
+                // JavaFX runtime modules required at package runtime.
+                "javafx.base",
+                "javafx.graphics",
+                "javafx.controls",
+                "javafx.swing",
+                "javafx.web",
                 // Required by JavaFX Marlin renderer (uses sun.misc.Unsafe).
                 "jdk.unsupported",
                 // Required by javafx.swing/JFXPanel on Windows for Swing event interop.


### PR DESCRIPTION
### Motivation
- The packaged Windows runtime was missing JavaFX runtime modules which caused startup failures (`ClassNotFoundException: com.sun.javafx.tk.quantum.QuantumToolkit` and `RuntimeException: No toolkit found`).

### Description
- Add JavaFX runtime modules (`javafx.base`, `javafx.graphics`, `javafx.controls`, `javafx.swing`, `javafx.web`) to `compose.desktop.application.nativeDistributions.modules` in `build.gradle.kts`, while keeping `jdk.unsupported` and `jdk.unsupported.desktop`.

### Testing
- Ran `bash ./gradlew -q compileKotlin` in this environment and the build could not run because no Java 17 toolchain is installed/configured, so compilation could not be validated here (toolchain error from Gradle).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d79eab088832789497fede8de195c)